### PR TITLE
fix: Aikar's `InitiatingHeapOccupancyPercent` value for large servers

### DIFF
--- a/app/data/Flags.tsx
+++ b/app/data/Flags.tsx
@@ -4,9 +4,9 @@ import { DisabledOptions } from "./interface/DisabledOptions";
  * Additional configuration for Aikar's flags.
  */
 const aikarsFlags = {
-    "base": "-XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true",
-    "standard": "-XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20",
-    "large": "-XX:G1NewSizePercent=40 -XX:G1MaxNewSizePercent=50 -XX:G1HeapRegionSize=16M -XX:G1ReservePercent=15"
+    "base": "-XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true",
+    "standard": "-XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:InitiatingHeapOccupancyPercent=15",
+    "large": "-XX:G1NewSizePercent=40 -XX:G1MaxNewSizePercent=50 -XX:G1HeapRegionSize=16M -XX:G1ReservePercent=15 -XX:InitiatingHeapOccupancyPercent=20"
 };
 
 /**


### PR DESCRIPTION
# Prerequisites
<!-- Change [ ] to [x] to check the boxes -->
- [x] A similar pull request does not already exist, or this pull request supersedes an existing pull request.
- [x] The project's contributing and relevant documentation have been acknowledged and adhered to.
- [x] I have signed off all of my relevant commits.

<!-- Closes issue #0 --> <!-- Uncomment if applicable -->

# Information
According to original [Aikar's post](https://aikar.co/2018/07/02/tuning-the-jvm-g1gc-garbage-collector-flags-for-minecraft/):

> If you have and use more than 12GB of memory, adjust the following:
>  - -XX:InitiatingHeapOccupancyPercent=20

This fixes Aikar's flag generation for large (12+ GB of RAM) servers.
